### PR TITLE
Update ERC20Interface to EIP20Interface

### DIFF
--- a/contracts/TokenHolder.sol
+++ b/contracts/TokenHolder.sol
@@ -87,7 +87,7 @@ contract TokenHolder is MultiSigWallet {
     /**
      * @notice Contract constructor.
      *
-     * @param _brandedToken erc20 contract address this user is part of.
+     * @param _brandedToken eip20 contract address this user is part of.
      * @param _coGateway utility chain gateway contract address.
      * @param _tokenRules Token rules contract address.
      * @param _required No of requirements for multi sig wallet.

--- a/contracts/TokenHolder.sol
+++ b/contracts/TokenHolder.sol
@@ -87,7 +87,7 @@ contract TokenHolder is MultiSigWallet {
     /**
      * @notice Contract constructor.
      *
-     * @param _brandedToken eip20 contract address this user is part of.
+     * @param _brandedToken eip20 contract address in utility chain.
      * @param _coGateway utility chain gateway contract address.
      * @param _tokenRules Token rules contract address.
      * @param _required No of requirements for multi sig wallet.

--- a/contracts/TokenHolder.sol
+++ b/contracts/TokenHolder.sol
@@ -87,7 +87,7 @@ contract TokenHolder is MultiSigWallet {
     /**
      * @notice Contract constructor.
      *
-     * @param _brandedToken eip20 contract address in utility chain.
+     * @param _brandedToken eip20 contract address deployed for an economy.
      * @param _coGateway utility chain gateway contract address.
      * @param _tokenRules Token rules contract address.
      * @param _required No of requirements for multi sig wallet.


### PR DESCRIPTION
- We should follow a common pattern of using EIP20Interface or ERC20Interface.

- As per discussion we need to follow EIP20Interface everywhere as it's already used in multiple places. e.g. EIP20Interface.

Resolves #17 