### PR TITLE
Travis build should work properly after solc upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,11 @@ before_install:
   - sudo apt-get install software-properties-common
   - sudo add-apt-repository -y ppa:ethereum/ethereum
   - sudo apt-get update
-  - sudo apt-get --allow-unauthenticated install solc
 install:
   - npm install
 before_script:
   - nohup sh tools/runGanacheCli.sh </dev/null >/dev/null 2>&1 &
-  - bash tools/compile.sh
+  - truffle compile
 script:
   - truffle test
 after_script:

--- a/package.json
+++ b/package.json
@@ -21,14 +21,12 @@
   "devDependencies": {
     "abi-decoder": "1.2.0",
     "assert": "1.4.1",
-    "bignumber.js": "4.1.0",
     "bn.js": "4.11.8",
     "eslint": "5.5.0",
     "eslint-config-airbnb-base": "13.1.0",
     "eslint-plugin-import": "2.14.0",
     "ethereumjs-util": "5.2.0",
     "ganache-cli": "6.1.8",
-    "solc": "0.4.23",
     "solidity-coverage": "0.5.11",
     "truffle": "5.0.0-beta.0",
     "web3": "1.0.0-beta.36"


### PR DESCRIPTION
**Problem**:

By default travis was installing latest solc version 5.0.0 which was breaking the tests. Compiling contracts with solc version 5.0.0 was throwing errors.

**Solution**:

We already specify specific version of truffle which installs specific version of solc as dependency.
The fix makes sure controlled version of solc is being used.

Current Solc Version: 0.4.24