### PR TITLE
Integration test when insufficient balance for tokenholder

### DIFF
--- a/test/integration_test/execute_rule/insufficient_tokenholder_funds.js
+++ b/test/integration_test/execute_rule/insufficient_tokenholder_funds.js
@@ -15,8 +15,25 @@
 /**
  * @dev This is the integration test for failing the executeRule when tokenholder
  *      has insufficient balance.
- *      In the tests,tokenholder address has 200 BTs. But,transfer of 250 tokens
- *      is initiated. It will fail as tokenholder doesn't have 250 tokens.
+ *      In the tests,TH has 200 BTs. But,transfer of 250 tokens
+ *      is initiated. It will fail as TH doesn't have 250 tokens.
+ *
+ *        Following steps are performed in the test :-
+ *
+ *        - EIP20TokenMock contract is deployed.
+ *        - Organization contract is deployed and worker is set.
+ *        - TokenRules contract is deployed.
+ *         TransferRule contract is deployed and it is registered in TokenRules.
+ *        - TokenHolder contract is deployed by providing the wallets and
+ *           required confirmations.
+ *        - Using EIP20TokenMock's setBalance method,tokens are provided to TH.
+ *        - We generate executable data for TransferRule contract's transferFrom
+ *           method.
+ *        - Relayer calls executeRule method of tokenholder contract.
+ *           After it's execution below verifications are done:
+ *            - RuleExecuted event.
+ *            - tokenholder balance.
+ *            - 'to' address balance.
  */
 const EthUtils = require('ethereumjs-util'),
   utils = require('../../test_lib/utils'),
@@ -96,7 +113,7 @@ contract('TokenHolder::executeRule', async (accounts) => {
         ephemeralPrivateKey1,
       );
 
-      let transactionResponse = await tokenHolder.executeRule(
+      const transactionResponse = await tokenHolder.executeRule(
         transferRule.address,
         transferFromExecutable,
         (currentNonce.toNumber() + 1),

--- a/test/integration_test/execute_rule/insufficient_tokenholder_funds.js
+++ b/test/integration_test/execute_rule/insufficient_tokenholder_funds.js
@@ -1,0 +1,131 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @dev This is the integration test for failing the executeRule when tokenholder
+ *      has insufficient balance.
+ *      In the tests,tokenholder address has 200 BTs. But,transfer of 250 tokens
+ *      is initiated. It will fail as tokenholder doesn't have 250 tokens.
+ */
+const EthUtils = require('ethereumjs-util'),
+  utils = require('../../test_lib/utils'),
+  AccountsProvider = utils.AccountProvider,
+  ExecuteRuleUtils = require('./utils'),
+  BN = require('bn.js'),
+  { Event } = require('../../test_lib/event_decoder');
+
+contract('TokenHolder::executeRule', async (accounts) => {
+
+  let accountProvider,
+    tokenHolder,
+    wallet1,
+    eip20TokenMock,
+    transferRule,
+    tokenRules,
+    ephemeralPrivateKey1,
+    ephemeralKeyAddress1,
+    keyData,
+    totalBalance = 200,
+    worker;
+
+  describe('ExecuteRule integration test', async () => {
+
+    it('Should fail when tokenholder has insufficient balance', async () => {
+
+      accountProvider = new AccountsProvider(accounts);
+
+      ( {
+        tokenHolder,
+        wallet1,
+        eip20TokenMock,
+        transferRule,
+        tokenRules,
+        worker,
+      } = await ExecuteRuleUtils.setup(accountProvider));
+
+      await eip20TokenMock.setBalance(tokenHolder.address, totalBalance);
+
+      ephemeralPrivateKey1 = '0xa8225c01ceeaf01d7bc7c1b1b929037bd4050967c5730c0b854263121b8399f3';
+      ephemeralKeyAddress1 = '0x62502C4DF73935D0D10054b0Fb8cC036534C6fb0';
+
+      let currentBlockNumber = await web3.eth.getBlockNumber(),
+        expirationHeight = currentBlockNumber + 50,
+        spendingLimit = 300;
+
+      await tokenHolder.submitAuthorizeSession(
+        ephemeralKeyAddress1,
+        spendingLimit,
+        expirationHeight,
+        { from: wallet1 },
+      );
+
+      keyData = await tokenHolder.ephemeralKeys(
+        ephemeralKeyAddress1,
+      );
+
+      let currentNonce = keyData.nonce,
+        amountTransferred = 250;
+
+      let nextAvailableNonce = currentNonce.toNumber() + 1;
+      const to = accountProvider.get();
+
+      // We are generating executable data to transfer 250 tokens.
+      // But, tokenholder has total 200 tokens.
+      const transferFromExecutable = await ExecuteRuleUtils.generateTransferFromExecutable(
+        tokenHolder.address,
+        to,
+        new BN(amountTransferred),
+      );
+
+      const { rsv } = await ExecuteRuleUtils.getExecuteRuleExTxData(
+        tokenHolder.address,
+        transferRule.address,
+        transferFromExecutable,
+        new BN(nextAvailableNonce),
+        ephemeralPrivateKey1,
+      );
+
+      let transactionResponse = await tokenHolder.executeRule(
+        transferRule.address,
+        transferFromExecutable,
+        (currentNonce.toNumber() + 1),
+        rsv.v,
+        EthUtils.bufferToHex(rsv.r),
+        EthUtils.bufferToHex(rsv.s),
+      );
+
+      const events = Event.decodeTransactionResponse(
+        transactionResponse,
+      );
+
+      // We should check against false here, however current version of web3
+      // returns null for false values in event log. After updating web3,
+      // this test might fail and we should use false (as intended).
+      assert.equal(events[0].args['_status'], null);
+
+      assert.equal(
+        (await eip20TokenMock.balanceOf(to)),
+        0,
+      );
+
+      assert.equal(
+        (await eip20TokenMock.balanceOf(tokenHolder.address)),
+        totalBalance,
+      );
+
+    });
+
+  });
+
+});

--- a/test/integration_test/execute_rule/utils.js
+++ b/test/integration_test/execute_rule/utils.js
@@ -1,0 +1,263 @@
+// Copyright 2018 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const TokenRules = artifacts.require('TokenRules'),
+  TokenHolder = artifacts.require('TokenHolder'),
+  TransferRule = artifacts.require('TransferRule'),
+  EIP20TokenMock = artifacts.require('EIP20TokenMock'),
+  Organization = artifacts.require('Organization'),
+  EthUtils = require('ethereumjs-util');
+
+/**
+ * It deploys the contracts,setup workers and registers a rule.
+ */
+module.exports.setup = async (accountProvider) => {
+
+  const eip20TokenMock = await this.createEIP20Token();
+
+  const {
+    owner,
+    organization,
+    worker
+  } = await this.setupOrganization(accountProvider);
+
+  const tokenRules = await this.tokenRules(organization, eip20TokenMock);
+
+  const transferRule = await this.transferRule(tokenRules.address);
+
+  const ruleName = 'transferRule';
+  const ruleAbi = `Rule abi of ${ruleName}`;
+
+  await tokenRules.registerRule(
+    ruleName,
+    transferRule.address,
+    ruleAbi,
+    { from: worker },
+  );
+
+  let wallets = [], wallet1;
+  wallet1 = accountProvider.get();
+  wallets.push(wallet1);
+
+  const tokenHolder = await this.setupTokenHolder(
+    eip20TokenMock.address,
+    tokenRules.address,
+    wallets,
+    1,
+  );
+
+  return {
+    owner,
+    worker,
+    eip20TokenMock,
+    organization,
+    tokenRules,
+    transferRule,
+    tokenHolder,
+    wallet1,
+  };
+};
+
+/**
+ * It returns an instance of tokenholder.
+ */
+module.exports.setupTokenHolder = async (token, tokenRules, wallets, required) => {
+
+  return (await TokenHolder.new(token, tokenRules, wallets, required));
+
+};
+
+/**
+ * It returns an instance of TokenRules by providing organization and
+ * EIP20Token address.
+ */
+module.exports.tokenRules = async (organization, token) => {
+
+  return (await TokenRules.new(organization.address, token.address));
+
+};
+
+/**
+ * It returns an instance of TransferRule contract.
+ *
+ */
+module.exports.transferRule = async (tokenRules) => {
+
+  return (await TransferRule.new(tokenRules));
+
+};
+
+/**
+ * It registers worker with expirationHeight and returns an instance of
+ * Organization.
+ */
+module.exports.setupOrganization = async (accountProvider) => {
+
+  const owner = accountProvider.get(),
+    worker = accountProvider.get(),
+    expirationHeight = 500;
+
+  const organization = await Organization.new({ from: owner });
+  await organization.setWorker(worker, expirationHeight);
+
+  return { owner, organization, worker };
+
+};
+
+/**
+ * Creates an EIP20 instance to be used during TokenRules::executeTransfers
+ * function's testing with the following defaults:
+ *      - conversionRate: 1
+ *      - conversionRateDecimals: 1
+ *      - symbol: 'OST'
+ *      - name: 'Open Simple Token'
+ *      - decimals: 1
+ */
+module.exports.createEIP20Token = async () => {
+  const token = await EIP20TokenMock.new(
+    1, 1, 'OST', 'Open Simple Token', 1,
+  );
+
+  return token;
+};
+
+/**
+ * It generates executable data for 'TransferFrom' method.
+ */
+module.exports.generateTransferFromExecutable = async (from, to, amount) => {
+
+  return web3.eth.abi.encodeFunctionCall(
+    {
+
+      name: 'transferFrom',
+      type: 'function',
+      inputs: [
+        {
+          type: 'address',
+          name: '_from'
+        },
+        {
+          type: 'address',
+          name: '_to'
+        },
+        {
+          type: 'uint256',
+          name: '_amount'
+        }
+      ]
+    },
+    [from, to, amount]
+  );
+
+}
+
+/**
+ * It returns hash of the data as per EIP-1077.
+ */
+module.exports.getExecuteRuleExTxHash = async (
+  tokenHolderAddress, ruleAddress, ruleData, nonce,
+)  => {
+  return web3.utils.soliditySha3(
+    {
+      t: 'bytes1', v: '0x19',
+    },
+    {
+      t: 'bytes1', v: '0x0',
+    },
+    {
+      t: 'address', v: tokenHolderAddress,
+    },
+    {
+      t: 'address', v: ruleAddress,
+    },
+    {
+      t: 'uint8', v: 0,
+    },
+    {
+      t: 'bytes32', v: web3.utils.keccak256(ruleData),
+    },
+    {
+      t: 'uint256', v: nonce,
+    },
+    {
+      t: 'uint8', v: 0,
+    },
+    {
+      t: 'uint8', v: 0,
+    },
+    {
+      t: 'uint8', v: 0,
+    },
+    {
+      t: 'bytes4', v: await this.generateExecuteRuleCallPrefix(),
+    },
+    {
+      t: 'uint8', v: 0,
+    },
+    {
+      t: 'bytes32', v: '0x0',
+    },
+  );
+}
+
+/**
+ * It provides call prefix of the executeRule method of tokenholder.
+ */
+module.exports.generateExecuteRuleCallPrefix = async () => {
+  return web3.eth.abi.encodeFunctionSignature({
+    name: 'executeRule',
+    type: 'function',
+    inputs: [
+      {
+        type: 'address', name: '',
+      },
+      {
+        type: 'bytes', name: '',
+      },
+      {
+        type: 'uint256', name: '',
+      },
+      {
+        type: 'uint8', name: '',
+      },
+      {
+        type: 'bytes32', name: '',
+      },
+      {
+        type: 'bytes32', name: '',
+      },
+    ],
+  });
+}
+
+/**
+ * It provides signature parameters and the hash of the data.
+ */
+module.exports.getExecuteRuleExTxData = async (
+  _tokenHolderAddress, _ruleAddress, _ruleData, _nonce, _ephemeralKey,
+) => {
+  const msgHash = await this.getExecuteRuleExTxHash(
+    _tokenHolderAddress, _ruleAddress, _ruleData, _nonce,
+  );
+
+  const rsv = EthUtils.ecsign(
+    EthUtils.toBuffer(msgHash),
+    EthUtils.toBuffer(_ephemeralKey),
+  );
+
+  return { msgHash, rsv };
+}
+
+
+


### PR DESCRIPTION
It tests executeRule method of tokenholder when it doesnt have insufficient number of tokens to be transferred.
Fixes #102 