### PR TITLE
TokenHolder executeRule & executeRedemption functions improvements.

### DIFF
--- a/contracts/TokenHolder.sol
+++ b/contracts/TokenHolder.sol
@@ -46,21 +46,21 @@ contract TokenHolder {
     );
 
     /**
-     * @param _msgHash Executed rule message hash according to EIP-1077.
+     * @param _messageHash Executed rule message hash according to EIP-1077.
      * @param _status Rule execution's status.
      */
     event RuleExecuted(
-        bytes32 _msgHash,
+        bytes32 _messageHash,
         bool _status
     );
 
     /**
-     * @param _msgHash Executed redemption request message hash according
+     * @param _messageHash Executed redemption request message hash according
      *                 to EIP-1077.
      * @param _status Redemption execution's status.
      */
     event RedemptionExecuted(
-        bytes32 _msgHash,
+        bytes32 _messageHash,
         bool _status
     );
 
@@ -277,7 +277,7 @@ contract TokenHolder {
      *
      *      Function requires:
      *          - _to address cannot be EIP20 Token.
-     *          - The key used to sign data is authorized and have not expired.
+     *          - key used to sign data is authorized and have not expired.
      *          - nonce is equal to the stored nonce value.
      *
      * @param _to The target contract address the transaction will be executed

--- a/contracts/TokenHolder.sol
+++ b/contracts/TokenHolder.sol
@@ -46,34 +46,21 @@ contract TokenHolder {
     );
 
     /**
-     * @dev Rule's hash is calculated by:
-     *          keccak256(
-     *               abi.encodePacked(
-     *                   to, // rule's address
-     *                   keccak(data), // data is rule's payload
-     *                   nonce, // non-used nonce for the specific session key
-     *                   v, r, s // signature
-     *               )
-     *           )
+     * @param _msgHash Executed rule message hash according to EIP-1077.
+     * @param _status Rule execution's status.
      */
     event RuleExecuted(
-        bytes32 _ruleHash,
+        bytes32 _msgHash,
         bool _status
     );
 
     /**
-     * @dev Redemption's hash is calculated by:
-     *          keccak256(
-     *               abi.encodePacked(
-     *                   to, // cogateway's address
-     *                   keccak(data), // data is cogateway::redeem function's payload
-     *                   nonce, // non-used nonce for the specific session key
-     *                   v, r, s // signature
-     *               )
-     *           )
+     * @param _msgHash Executed redemption request message hash according
+     *                 to EIP-1077.
+     * @param _status Redemption execution's status.
      */
-    event RedeemExecuted(
-        bytes32 _redemptionHash,
+    event RedemptionExecuted(
+        bytes32 _msgHash,
         bool _status
     );
 
@@ -106,15 +93,9 @@ contract TokenHolder {
         )
     );
 
-    bytes4 public constant EXECUTE_REDEEM_CALLPREFIX = bytes4(
+    bytes4 public constant EXECUTE_REDEMPTION_CALLPREFIX = bytes4(
         keccak256(
             "executeRedemption(address,bytes,uint256,uint8,bytes32,bytes32)"
-        )
-    );
-
-    bytes4 public constant COGATEWAY_REDEEM_CALLPREFIX = bytes4(
-        keccak256(
-            "redeem(uint256,address,uint256,uint256,uint256,bytes32)"
         )
     );
 
@@ -148,9 +129,8 @@ contract TokenHolder {
     /** Requires that key is in authorized state. */
     modifier keyIsAuthorized(address _key)
     {
-        AuthorizationStatus status = sessionKeys[_key].status;
         require(
-            status == AuthorizationStatus.AUTHORIZED,
+            sessionKeys[_key].status == AuthorizationStatus.AUTHORIZED,
             "Key is not authorized."
         );
         _;
@@ -159,9 +139,8 @@ contract TokenHolder {
     /** Requires that key was not authorized. */
     modifier keyDoesNotExist(address _key)
     {
-        AuthorizationStatus status = sessionKeys[_key].status;
         require(
-            status == AuthorizationStatus.NOT_AUTHORIZED,
+            sessionKeys[_key].status == AuthorizationStatus.NOT_AUTHORIZED,
             "Key exists."
         );
         _;
@@ -299,8 +278,7 @@ contract TokenHolder {
      *      Function requires:
      *          - _to address cannot be EIP20 Token.
      *          - The key used to sign data is authorized and have not expired.
-     *          - nonce matches the next available one (+1 of the last
-     *            used one).
+     *          - nonce is equal to the stored nonce value.
      *
      * @param _to The target contract address the transaction will be executed
      *            upon.
@@ -316,9 +294,9 @@ contract TokenHolder {
         address _to,
         bytes calldata _data,
         uint256 _nonce,
-        uint8 _v,
         bytes32 _r,
-        bytes32 _s
+        bytes32 _s,
+        uint8 _v
     )
         external
         payable
@@ -334,16 +312,14 @@ contract TokenHolder {
             "'to' address is TokenHolder address itself."
         );
 
-        bytes32 messageHash = bytes32(0);
-        address sessionKey = address(0);
-        (messageHash, sessionKey) = verifyExecutableTransaction(
+        (bytes32 messageHash, address sessionKey) = verifyExecutableTransaction(
             EXECUTE_RULE_CALLPREFIX,
             _to,
             _data,
             _nonce,
-            _v,
             _r,
-            _s
+            _s,
+            _v
         );
 
         SessionKeyData storage sessionKeyData = sessionKeys[sessionKey];
@@ -363,19 +339,8 @@ contract TokenHolder {
 
         TokenRules(tokenRules).disallowTransfers();
 
-        bytes32 ruleHash = keccak256(
-            abi.encodePacked(
-                _to,
-                keccak256(_data),
-                _nonce,
-                _v,
-                _r,
-                _s
-            )
-        );
-
         emit RuleExecuted(
-            ruleHash,
+            messageHash,
             executionStatus_
         );
     }
@@ -384,9 +349,9 @@ contract TokenHolder {
         address _to,
         bytes calldata _data,
         uint256 _nonce,
-        uint8 _v,
         bytes32 _r,
-        bytes32 _s
+        bytes32 _s,
+        uint8 _v
     )
         external
         payable
@@ -398,23 +363,14 @@ contract TokenHolder {
 
         require(_to == coGateway,"'to' address is not coGateway address.");
 
-        bytes4 functionSelector = bytesToBytes4(_data);
-
-        require(
-            functionSelector == COGATEWAY_REDEEM_CALLPREFIX,
-            "Retrieved function selector does not match to CoGateway::redeem."
-        );
-
-        bytes32 messageHash = bytes32(0);
-        address sessionKey = address(0);
-        (messageHash, sessionKey) = verifyExecutableTransaction(
-            EXECUTE_REDEEM_CALLPREFIX,
+        (bytes32 messageHash, address sessionKey) = verifyExecutableTransaction(
+            EXECUTE_REDEMPTION_CALLPREFIX,
             _to,
             _data,
             _nonce,
-            _v,
             _r,
-            _s
+            _s,
+            _v
         );
 
         SessionKeyData storage sessionKeyData = sessionKeys[sessionKey];
@@ -427,40 +383,10 @@ contract TokenHolder {
 
         token.approve(_to, 0);
 
-        bytes32 redemptionHash = keccak256(
-            abi.encodePacked(
-                _to,
-                keccak256(_data),
-                _nonce,
-                _v,
-                _r,
-                _s
-            )
-        );
-
-        emit RedeemExecuted(
-            redemptionHash,
+        emit RedemptionExecuted(
+            messageHash,
             executionStatus_
         );
-    }
-
-
-    /* Public Functions */
-
-    /**
-     * @dev Retrieves the first 4 bytes of input byte array into byte4.
-     *      Function requires:
-     *          - Input byte array's length is greater than or equal to 4.
-     */
-    function bytesToBytes4(bytes memory _input) public pure returns (bytes4 out_) {
-        require(
-            _input.length >= 4,
-            "Input bytes length is less than 4."
-        );
-
-        for (uint8 i = 0; i < 4; i++) {
-            out_ |= bytes4(_input[i] & 0xFF) >> (i * 8);
-        }
     }
 
 
@@ -471,9 +397,9 @@ contract TokenHolder {
         address _to,
         bytes memory _data,
         uint256 _nonce,
-        uint8 _v,
         bytes32 _r,
-        bytes32 _s
+        bytes32 _s,
+        uint8 _v
     )
         private
         returns (bytes32 messageHash_, address key_)
@@ -489,20 +415,22 @@ contract TokenHolder {
 
         SessionKeyData storage keyData = sessionKeys[key_];
 
+        // The following check appears here and not higher in the stack,
+        // as session key is only retrieved here, after calculation
+        // of message hash according EIP-1077 and retriving the key
+        // from the signature (_r, _s, _v).
         require(
             keyData.status == AuthorizationStatus.AUTHORIZED &&
             keyData.expirationHeight > block.number,
             "Session key is not active."
         );
 
-        uint256 expectedNonce = keyData.nonce.add(1);
-
         require(
-            _nonce == expectedNonce,
-            "The next nonce is not provided."
+            _nonce == keyData.nonce,
+            "Incorrect nonce is specified."
         );
 
-        keyData.nonce = expectedNonce;
+        keyData.nonce = keyData.nonce.add(1);
     }
 
     /**

--- a/contracts/TokenRules.sol
+++ b/contracts/TokenRules.sol
@@ -133,7 +133,7 @@ contract TokenRules is Organized {
 
         token = _token;
 
-        areDirectTransfersEnabled = false;
+        areDirectTransfersEnabled = true;
     }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openstfoundation/openst-contracts",
-    "version": "0.9.4",
+    "version": "0.10.0",
     "description": "",
     "keywords": [
         "openst",

--- a/test/token_holder/execute_redemption.js
+++ b/test/token_holder/execute_redemption.js
@@ -513,7 +513,7 @@ contract('TokenHolder::redeem', async (accounts) => {
             Event.assertEqual(events[0], {
                 name: 'RedemptionExecuted',
                 args: {
-                    _msgHash: exTxHash,
+                    _messageHash: exTxHash,
                     _status: true,
                 },
             });
@@ -573,7 +573,7 @@ contract('TokenHolder::redeem', async (accounts) => {
             Event.assertEqual(events[0], {
                 name: 'RedemptionExecuted',
                 args: {
-                    _msgHash: exTxHash,
+                    _messageHash: exTxHash,
                     _status: false,
                 },
             });

--- a/test/token_holder/execute_redemption.js
+++ b/test/token_holder/execute_redemption.js
@@ -27,31 +27,6 @@ const sessionPrivateKey1 = '0xa8225c01ceeaf01d7bc7c1b1b929037bd4050967c5730c0b85
 // const sessionPublicKey2 = '0xBbfd1BF77dA692abc82357aC001415b98d123d17';
 const sessionPrivateKey2 = '0x6817f551bbc3e12b8fe36787ab192c921390d6176a3324ed02f96935a370bc41';
 
-function generateRedemptionHash(
-    to, data, nonce, v, r, s,
-) {
-    return web3.utils.soliditySha3(
-        {
-            t: 'address', v: to,
-        },
-        {
-            t: 'bytes32', v: web3.utils.keccak256(data),
-        },
-        {
-            t: 'uint256', v: nonce,
-        },
-        {
-            t: 'uint8', v,
-        },
-        {
-            t: 'bytes32', v: r,
-        },
-        {
-            t: 'bytes32', v: s,
-        },
-
-    );
-}
 
 function generateTokenHolderexecuteRedemptionFunctionCallPrefix() {
     return web3.eth.abi.encodeFunctionSignature({
@@ -197,7 +172,7 @@ contract('TokenHolder::redeem', async (accounts) => {
                 sessionPublicKey1,
             );
 
-            const tokenHolderNonce = 1;
+            const tokenHolderNonce = 0;
 
             const amount = 10;
             const beneficiary = accountProvider.get();
@@ -222,9 +197,9 @@ contract('TokenHolder::redeem', async (accounts) => {
                     coGateway.address,
                     coGatewayRedeemFunctionData,
                     tokenHolderNonce,
-                    exTxSignature.v,
                     EthUtils.bufferToHex(exTxSignature.r),
                     EthUtils.bufferToHex(exTxSignature.s),
+                    exTxSignature.v,
                     {
                         from: accountProvider.get(),
                         value: 1 /* bounty */,
@@ -247,7 +222,7 @@ contract('TokenHolder::redeem', async (accounts) => {
                 sessionPublicKey1,
             );
 
-            const tokenHolderNonce = 1;
+            const tokenHolderNonce = 0;
 
             const amount = 10;
             const beneficiary = accountProvider.get();
@@ -277,9 +252,9 @@ contract('TokenHolder::redeem', async (accounts) => {
                     coGateway.address,
                     coGatewayRedeemFunctionData,
                     tokenHolderNonce,
-                    exTxSignature.v,
                     EthUtils.bufferToHex(exTxSignature.r),
                     EthUtils.bufferToHex(exTxSignature.s),
+                    exTxSignature.v,
                     {
                         from: accountProvider.get(),
                         value: 1 /* bounty */,
@@ -302,7 +277,7 @@ contract('TokenHolder::redeem', async (accounts) => {
                 sessionPublicKey1,
             );
 
-            const tokenHolderNonce = 1;
+            const tokenHolderNonce = 0;
 
             const amount = 10;
             const beneficiary = accountProvider.get();
@@ -332,9 +307,9 @@ contract('TokenHolder::redeem', async (accounts) => {
                     coGateway.address,
                     coGatewayRedeemFunctionData,
                     tokenHolderNonce,
-                    exTxSignature.v,
                     EthUtils.bufferToHex(exTxSignature.r),
                     EthUtils.bufferToHex(exTxSignature.s),
+                    exTxSignature.v,
                     {
                         from: accountProvider.get(),
                         value: 1 /* bounty */,
@@ -363,15 +338,15 @@ contract('TokenHolder::redeem', async (accounts) => {
             const redeemerNonce = 1;
             const hashLock = web3.utils.soliditySha3('hash-lock');
 
-            // Correct nonce is 1.
-            const tokenHolderInvalidNonce0 = 0;
+            // Correct nonce is 0.
+            const tokenHolderInvalidNonce = 1;
 
             const {
                 coGatewayRedeemFunctionData: coGatewayRedeemFunctionData0,
                 exTxSignature: exTxSignature0,
             } = await generateCoGatewayRedeemFunctionExTx(
                 tokenHolder,
-                tokenHolderInvalidNonce0,
+                tokenHolderInvalidNonce,
                 sessionPrivateKey1,
                 coGateway,
                 amount, beneficiary, gasPrice, gasLimit, redeemerNonce, hashLock,
@@ -381,51 +356,21 @@ contract('TokenHolder::redeem', async (accounts) => {
                 tokenHolder.executeRedemption(
                     coGateway.address,
                     coGatewayRedeemFunctionData0,
-                    tokenHolderInvalidNonce0,
-                    exTxSignature0.v,
+                    tokenHolderInvalidNonce,
                     EthUtils.bufferToHex(exTxSignature0.r),
                     EthUtils.bufferToHex(exTxSignature0.s),
+                    exTxSignature0.v,
                     {
                         from: accountProvider.get(),
                         value: 1 /* bounty */,
                     },
                 ),
                 'Should revert as ExTx is signed with an invalid nonce.',
-                'The next nonce is not provided.',
-            );
-
-            // Correct nonce is 1.
-            const tokenHolderInvalidNonce2 = 2;
-
-            const {
-                coGatewayRedeemFunctionData: coGatewayRedeemFunctionData2,
-                exTxSignature: exTxSignature2,
-            } = await generateCoGatewayRedeemFunctionExTx(
-                tokenHolder,
-                tokenHolderInvalidNonce2,
-                sessionPrivateKey1,
-                coGateway,
-                amount, beneficiary, gasPrice, gasLimit, redeemerNonce, hashLock,
-            );
-
-            await Utils.expectRevert(
-                tokenHolder.executeRedemption(
-                    coGateway.address,
-                    coGatewayRedeemFunctionData2,
-                    tokenHolderInvalidNonce2,
-                    exTxSignature2.v,
-                    EthUtils.bufferToHex(exTxSignature2.r),
-                    EthUtils.bufferToHex(exTxSignature2.s),
-                    {
-                        from: accountProvider.get(),
-                        value: 1 /* bounty */,
-                    },
-                ),
-                'Should revert as ExTx is signed with an invalid nonce.',
-                'The next nonce is not provided.',
+                'Incorrect nonce is specified.',
             );
         });
     });
+
     contract('Redeem Executed', async () => {
         const accountProvider = new AccountProvider(accounts);
 
@@ -448,7 +393,7 @@ contract('TokenHolder::redeem', async (accounts) => {
             const redeemerNonce = 1;
             const hashLock = web3.utils.soliditySha3('hash-lock');
 
-            const tokenHolderNonce = 1;
+            const tokenHolderNonce = 0;
 
             const {
                 coGatewayRedeemFunctionData,
@@ -467,9 +412,9 @@ contract('TokenHolder::redeem', async (accounts) => {
                 coGateway.address,
                 coGatewayRedeemFunctionData,
                 tokenHolderNonce,
-                exTxSignature.v,
                 EthUtils.bufferToHex(exTxSignature.r),
                 EthUtils.bufferToHex(exTxSignature.s),
+                exTxSignature.v,
                 {
                     from: accountProvider.get(),
                     value: bounty,
@@ -482,9 +427,9 @@ contract('TokenHolder::redeem', async (accounts) => {
                 coGateway.address,
                 coGatewayRedeemFunctionData,
                 tokenHolderNonce,
-                exTxSignature.v,
                 EthUtils.bufferToHex(exTxSignature.r),
                 EthUtils.bufferToHex(exTxSignature.s),
+                exTxSignature.v,
                 {
                     from: accountProvider.get(),
                     value: bounty,
@@ -534,10 +479,11 @@ contract('TokenHolder::redeem', async (accounts) => {
             const redeemerNonce = 1;
             const hashLock = web3.utils.soliditySha3('hash-lock');
 
-            const tokenHolderNonce = 1;
+            const tokenHolderNonce = 0;
 
             const {
                 coGatewayRedeemFunctionData,
+                exTxHash,
                 exTxSignature,
             } = await generateCoGatewayRedeemFunctionExTx(
                 tokenHolder,
@@ -551,9 +497,9 @@ contract('TokenHolder::redeem', async (accounts) => {
                 coGateway.address,
                 coGatewayRedeemFunctionData,
                 tokenHolderNonce,
-                exTxSignature.v,
                 EthUtils.bufferToHex(exTxSignature.r),
                 EthUtils.bufferToHex(exTxSignature.s),
+                exTxSignature.v,
                 {
                     from: accountProvider.get(),
                     value: 1,
@@ -565,16 +511,9 @@ contract('TokenHolder::redeem', async (accounts) => {
             assert.strictEqual(events.length, 1);
 
             Event.assertEqual(events[0], {
-                name: 'RedeemExecuted',
+                name: 'RedemptionExecuted',
                 args: {
-                    _redemptionHash: generateRedemptionHash(
-                        coGateway.address,
-                        coGatewayRedeemFunctionData,
-                        redeemerNonce,
-                        exTxSignature.v,
-                        EthUtils.bufferToHex(exTxSignature.r),
-                        EthUtils.bufferToHex(exTxSignature.s),
-                    ),
+                    _msgHash: exTxHash,
                     _status: true,
                 },
             });
@@ -598,10 +537,11 @@ contract('TokenHolder::redeem', async (accounts) => {
             const redeemerNonce = 1;
             const hashLock = web3.utils.soliditySha3('hash-lock');
 
-            const tokenHolderNonce = 1;
+            const tokenHolderNonce = 0;
 
             const {
                 coGatewayRedeemFunctionData,
+                exTxHash,
                 exTxSignature,
             } = await generateCoGatewayRedeemFunctionExTx(
                 tokenHolder,
@@ -617,9 +557,9 @@ contract('TokenHolder::redeem', async (accounts) => {
                 coGateway.address,
                 coGatewayRedeemFunctionData,
                 tokenHolderNonce,
-                exTxSignature.v,
                 EthUtils.bufferToHex(exTxSignature.r),
                 EthUtils.bufferToHex(exTxSignature.s),
+                exTxSignature.v,
                 {
                     from: accountProvider.get(),
                     value: 1,
@@ -631,19 +571,222 @@ contract('TokenHolder::redeem', async (accounts) => {
             assert.strictEqual(events.length, 1);
 
             Event.assertEqual(events[0], {
-                name: 'RedeemExecuted',
+                name: 'RedemptionExecuted',
                 args: {
-                    _redemptionHash: generateRedemptionHash(
-                        coGateway.address,
-                        coGatewayRedeemFunctionData,
-                        redeemerNonce,
-                        exTxSignature.v,
-                        EthUtils.bufferToHex(exTxSignature.r),
-                        EthUtils.bufferToHex(exTxSignature.s),
-                    ),
+                    _msgHash: exTxHash,
                     _status: false,
                 },
             });
+        });
+    });
+
+    contract('Returned Execution Status', async () => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Checks that return value is true in case of successfull execution.', async () => {
+            const {
+                tokenHolder,
+                coGateway,
+            } = await prepare(
+                accountProvider,
+                50, /* spendingLimit */
+                100, /* deltaExpirationHeight */
+                sessionPublicKey1,
+            );
+
+            const amount = 10;
+            const beneficiary = accountProvider.get();
+            const gasPrice = 10;
+            const gasLimit = 100;
+            const redeemerNonce = 1;
+            const hashLock = web3.utils.soliditySha3('hash-lock');
+
+            const tokenHolderNonce = 0;
+
+            const {
+                coGatewayRedeemFunctionData,
+                exTxSignature,
+            } = await generateCoGatewayRedeemFunctionExTx(
+                tokenHolder,
+                tokenHolderNonce,
+                sessionPrivateKey1,
+                coGateway,
+                amount, beneficiary, gasPrice, gasLimit, redeemerNonce, hashLock,
+            );
+
+            const executionStatus = await tokenHolder.executeRedemption.call(
+                coGateway.address,
+                coGatewayRedeemFunctionData,
+                tokenHolderNonce,
+                EthUtils.bufferToHex(exTxSignature.r),
+                EthUtils.bufferToHex(exTxSignature.s),
+                exTxSignature.v,
+                {
+                    from: accountProvider.get(),
+                    value: 1,
+                },
+            );
+
+            assert.isOk(
+                executionStatus,
+            );
+        });
+
+        it('Checks that return value is false in case of failing execution.', async () => {
+            const {
+                tokenHolder,
+                coGateway,
+            } = await prepare(
+                accountProvider,
+                50, /* spendingLimit */
+                100, /* deltaExpirationHeight */
+                sessionPublicKey1,
+            );
+
+            const amount = 10;
+            const beneficiary = accountProvider.get();
+            const gasPrice = 10;
+            const gasLimit = 100;
+            const redeemerNonce = 1;
+            const hashLock = web3.utils.soliditySha3('hash-lock');
+
+            const tokenHolderNonce = 0;
+
+            const {
+                coGatewayRedeemFunctionData,
+                exTxSignature,
+            } = await generateCoGatewayRedeemFunctionExTx(
+                tokenHolder,
+                tokenHolderNonce,
+                sessionPrivateKey1,
+                coGateway,
+                amount, beneficiary, gasPrice, gasLimit, redeemerNonce, hashLock,
+            );
+
+            await coGateway.makeRedemptionToFail();
+
+            const executionStatus = await tokenHolder.executeRedemption.call(
+                coGateway.address,
+                coGatewayRedeemFunctionData,
+                tokenHolderNonce,
+                EthUtils.bufferToHex(exTxSignature.r),
+                EthUtils.bufferToHex(exTxSignature.s),
+                exTxSignature.v,
+                {
+                    from: accountProvider.get(),
+                    value: 1,
+                },
+            );
+
+            assert.isNotOk(
+                executionStatus,
+            );
+        });
+    });
+
+    contract('Nonce handling', async () => {
+        const accountProvider = new AccountProvider(accounts);
+
+        it('Checks that nonce is incremented in case of successfull execution.', async () => {
+            const {
+                tokenHolder,
+                coGateway,
+            } = await prepare(
+                accountProvider,
+                50, /* spendingLimit */
+                100, /* deltaExpirationHeight */
+                sessionPublicKey1,
+            );
+
+            const amount = 10;
+            const beneficiary = accountProvider.get();
+            const gasPrice = 10;
+            const gasLimit = 100;
+            const redeemerNonce = 1;
+            const hashLock = web3.utils.soliditySha3('hash-lock');
+
+            const tokenHolderNonce = 0;
+
+            const {
+                coGatewayRedeemFunctionData,
+                exTxSignature,
+            } = await generateCoGatewayRedeemFunctionExTx(
+                tokenHolder,
+                tokenHolderNonce,
+                sessionPrivateKey1,
+                coGateway,
+                amount, beneficiary, gasPrice, gasLimit, redeemerNonce, hashLock,
+            );
+
+            await tokenHolder.executeRedemption(
+                coGateway.address,
+                coGatewayRedeemFunctionData,
+                tokenHolderNonce,
+                EthUtils.bufferToHex(exTxSignature.r),
+                EthUtils.bufferToHex(exTxSignature.s),
+                exTxSignature.v,
+                {
+                    from: accountProvider.get(),
+                    value: 1,
+                },
+            );
+
+            // Checks that nonce is updated.
+            assert.isOk(
+                (await tokenHolder.sessionKeys.call(sessionPublicKey1)).nonce.eqn(1),
+            );
+        });
+
+        it('Checks that return value is false in case of failing execution.', async () => {
+            const {
+                tokenHolder,
+                coGateway,
+            } = await prepare(
+                accountProvider,
+                50, /* spendingLimit */
+                100, /* deltaExpirationHeight */
+                sessionPublicKey1,
+            );
+
+            const amount = 10;
+            const beneficiary = accountProvider.get();
+            const gasPrice = 10;
+            const gasLimit = 100;
+            const redeemerNonce = 1;
+            const hashLock = web3.utils.soliditySha3('hash-lock');
+
+            const tokenHolderNonce = 0;
+
+            const {
+                coGatewayRedeemFunctionData,
+                exTxSignature,
+            } = await generateCoGatewayRedeemFunctionExTx(
+                tokenHolder,
+                tokenHolderNonce,
+                sessionPrivateKey1,
+                coGateway,
+                amount, beneficiary, gasPrice, gasLimit, redeemerNonce, hashLock,
+            );
+
+            await coGateway.makeRedemptionToFail();
+
+            await tokenHolder.executeRedemption(
+                coGateway.address,
+                coGatewayRedeemFunctionData,
+                tokenHolderNonce,
+                EthUtils.bufferToHex(exTxSignature.r),
+                EthUtils.bufferToHex(exTxSignature.s),
+                exTxSignature.v,
+                {
+                    from: accountProvider.get(),
+                    value: 1,
+                },
+            );
+
+            // Checks that nonce is updated.
+            assert.isOk(
+                (await tokenHolder.sessionKeys.call(sessionPublicKey1)).nonce.eqn(1),
+            );
         });
     });
 });

--- a/test/token_holder/execute_rule.js
+++ b/test/token_holder/execute_rule.js
@@ -604,7 +604,7 @@ contract('TokenHolder::executeRule', async () => {
             Event.assertEqual(events[0], {
                 name: 'RuleExecuted',
                 args: {
-                    _msgHash: exTxHash,
+                    _messageHash: exTxHash,
                     _status: true,
                 },
             });
@@ -656,7 +656,7 @@ contract('TokenHolder::executeRule', async () => {
             Event.assertEqual(events[0], {
                 name: 'RuleExecuted',
                 args: {
-                    _msgHash: exTxHash,
+                    _messageHash: exTxHash,
                     _status: false,
                 },
             });

--- a/test/token_rules/constructor.js
+++ b/test/token_rules/constructor.js
@@ -58,7 +58,7 @@ contract('TokenRules::constructor', async () => {
 
             assert.strictEqual(
                 await tokenRules.areDirectTransfersEnabled.call(),
-                false,
+                true,
             );
         });
     });


### PR DESCRIPTION
- TokenHolder's RuleExecuted event signature includes messageHash (ExTx hash according to EIP-1077) instead of "rule hash".
- TokenHolder's RedeemExecuted event renamed to RedemptionExecuted.
- TokenHolder's RedemptionExecuted event signature includes messageHash (ExTx hash according to EIP-1077) instead of "redemption hash".
- EXECUTE_REDEMPTION_CALLPREFIX has been removed. In TokenHolder::executeRedemption function we do not check anymore that call prefix (function selector) of the rule is redeem function.
- Minor improvements for gas saving.
- Instead of the (v, r, s) order function received the signature in the following order: (r, s, v)
- Direct transfers in TokenRules are enabled in constructor.