### PR TITLE
Pricer rule calculation

### DIFF
--- a/contracts/rules/PricerRule.sol
+++ b/contracts/rules/PricerRule.sol
@@ -394,7 +394,10 @@ contract PricerRule is Organized {
         view
         returns (uint256)
     {
-        return _payCurrencyAmount
+        return (10 ** uint256(requiredPriceOracleDecimals))
+            .mul(
+                _payCurrencyAmount
+            )
             .mul(
                 conversionRateFromBaseCurrencyToToken
             )

--- a/test/pricer_rule/pay.js
+++ b/test/pricer_rule/pay.js
@@ -46,10 +46,11 @@ async function prepare(accountProvider) {
 }
 
 function convertPayCurrencyToToken(
-  amount, price, conversionRate, conversionRateDecimals,
+  requiredPriceOracleDecimals, amount, price, conversionRate, conversionRateDecimals,
 ) {
+  const requiredPriceOracleDecimalsBN = (new BN(10)).pow(requiredPriceOracleDecimals);
   const conversionRateDecimalsBN = (new BN(10)).pow(conversionRateDecimals);
-  return ((amount.mul(conversionRate)).div(price)).div(conversionRateDecimalsBN);
+  return ((requiredPriceOracleDecimalsBN.mul(amount).mul(conversionRate)).div(price)).div(conversionRateDecimalsBN);
 }
 
 contract('PricerRule::pay', async () => {
@@ -269,10 +270,10 @@ contract('PricerRule::pay', async () => {
       );
 
       const convertedAmount1BN = convertPayCurrencyToToken(
-        amount1BN, oraclePriceBN, new BN(conversionRate), new BN(conversionRateDecimals),
+        new BN(requiredPriceOracleDecimals), amount1BN, oraclePriceBN, new BN(conversionRate), new BN(conversionRateDecimals),
       );
       const convertedAmount2BN = convertPayCurrencyToToken(
-        amount2BN, oraclePriceBN, new BN(conversionRate), new BN(conversionRateDecimals),
+        new BN(requiredPriceOracleDecimals), amount2BN, oraclePriceBN, new BN(conversionRate), new BN(conversionRateDecimals),
       );
 
 


### PR DESCRIPTION
The PR adds  missing the `10** requiredPriceOracleDecimals`
which is set to `18` always in PriceOracle contract