### PR TITLE
PricerRule convertPayCurrencyToToken method missing factor fix

### DIFF
--- a/contracts/rules/PricerRule.sol
+++ b/contracts/rules/PricerRule.sol
@@ -71,9 +71,9 @@ contract PricerRule is Organized {
     uint256 public conversionRateDecimalsFromBaseCurrencyToToken;
 
     /**
-    * @dev Required decimals for EIP20Token. Since Pay method can be called multiple
-    *      times, for optimization it's fetched from eip20Token and stored.
-    */
+     * @dev Required decimals for EIP20Token. Since Pay method can be called multiple
+     *      times, for optimization it's fetched from eip20Token and stored.
+     */
     uint8 public eip20TokenDecimals;
 
     /**

--- a/contracts/rules/PricerRule.sol
+++ b/contracts/rules/PricerRule.sol
@@ -398,9 +398,6 @@ contract PricerRule is Organized {
             .mul(
                 conversionRateFromBaseCurrencyToToken
             )
-            .mul(
-                (10 ** uint256(requiredPriceOracleDecimals))
-            )
             .div(
                 10 ** conversionRateDecimalsFromBaseCurrencyToToken
             )

--- a/contracts/rules/PricerRule.sol
+++ b/contracts/rules/PricerRule.sol
@@ -394,7 +394,10 @@ contract PricerRule is Organized {
         view
         returns (uint256)
     {
-        return _payCurrencyAmount
+        return (10 ** uint256(requiredPriceOracleDecimals))
+            .mul(
+                _payCurrencyAmount
+            )
             .mul(
                 conversionRateFromBaseCurrencyToToken
             )

--- a/contracts/rules/PricerRule.sol
+++ b/contracts/rules/PricerRule.sol
@@ -71,8 +71,8 @@ contract PricerRule is Organized {
     uint256 public conversionRateDecimalsFromBaseCurrencyToToken;
 
     /**
-    * @dev Required decimals for EIP20Token. Pay method can be called multiple times.
-    *      For optimization it's fetched from eip20Token and stored.
+    * @dev Required decimals for EIP20Token. Since Pay method can be called multiple times,
+    *      for optimization it's fetched from eip20Token and stored.
     */
     uint8 public eip20TokenDecimals;
 

--- a/contracts/rules/PricerRule.sol
+++ b/contracts/rules/PricerRule.sol
@@ -71,8 +71,8 @@ contract PricerRule is Organized {
     uint256 public conversionRateDecimalsFromBaseCurrencyToToken;
 
     /**
-    * @dev Required decimals for EIP20Token. Since Pay method can be called multiple times,
-    *      for optimization it's fetched from eip20Token and stored.
+    * @dev Required decimals for EIP20Token. Since Pay method can be called multiple
+    *      times, for optimization it's fetched from eip20Token and stored.
     */
     uint8 public eip20TokenDecimals;
 

--- a/contracts/rules/PricerRule.sol
+++ b/contracts/rules/PricerRule.sol
@@ -394,12 +394,12 @@ contract PricerRule is Organized {
         view
         returns (uint256)
     {
-        return (10 ** uint256(requiredPriceOracleDecimals))
-            .mul(
-                _payCurrencyAmount
-            )
+        return _payCurrencyAmount
             .mul(
                 conversionRateFromBaseCurrencyToToken
+            )
+            .mul(
+                (10 ** uint256(requiredPriceOracleDecimals))
             )
             .div(
                 10 ** conversionRateDecimalsFromBaseCurrencyToToken

--- a/contracts/rules/PricerRule.sol
+++ b/contracts/rules/PricerRule.sol
@@ -398,6 +398,9 @@ contract PricerRule is Organized {
             .mul(
                 conversionRateFromBaseCurrencyToToken
             )
+            .mul(
+                10 ** uint256(requiredPriceOracleDecimals)
+            )
             .div(
                 10 ** conversionRateDecimalsFromBaseCurrencyToToken
             )

--- a/contracts/rules/PricerRule.sol
+++ b/contracts/rules/PricerRule.sol
@@ -71,6 +71,12 @@ contract PricerRule is Organized {
     uint256 public conversionRateDecimalsFromBaseCurrencyToToken;
 
     /**
+    * @dev Required decimals for EIP20Token. Pay method can be called multiple times.
+    *      For optimization it's fetched from eip20Token and stored.
+    */
+    uint8 public eip20TokenDecimals;
+
+    /**
      * @dev Required decimals for price oracles.
      */
     uint8 public requiredPriceOracleDecimals;
@@ -149,6 +155,8 @@ contract PricerRule is Organized {
         );
 
         eip20Token = EIP20TokenInterface(_eip20Token);
+
+        eip20TokenDecimals = EIP20TokenInterface(_eip20Token).decimals();
 
         baseCurrencyCode = _baseCurrencyCode;
 
@@ -399,7 +407,7 @@ contract PricerRule is Organized {
                 conversionRateFromBaseCurrencyToToken
             )
             .mul(
-                10 ** uint256(requiredPriceOracleDecimals)
+                10 ** uint256(eip20TokenDecimals)
             )
             .div(
                 10 ** conversionRateDecimalsFromBaseCurrencyToToken

--- a/npm_package/test/run_npm_package_test.sh
+++ b/npm_package/test/run_npm_package_test.sh
@@ -33,7 +33,7 @@ node "${script_dir_path}/index.js" || exit 1
 
 echo "Cleaning up generated files."
 rm -r "${script_dir_path}/node_modules" || exit 1
-rm openstfoundation-openst-contracts-0.10.0-beta.1.tgz || exit 1
+rm openstfoundation-openst-contracts-0.10.0-beta.2.tgz || exit 1
 rm package.json || exit 1
 rm package-lock.json || exit 1
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@openstfoundation/openst-contracts",
-    "version": "0.10.0-beta.1",
+    "version": "0.10.0-beta.2",
     "description": "Openst contracts provide ABIs and BINs for EVM smart contracts to enable developers to program token economies.",
     "author": "OpenST Foundation Ltd.",
     "license": "Apache v2.0",

--- a/test/delayed_recovery_module/execute_recovery.js
+++ b/test/delayed_recovery_module/execute_recovery.js
@@ -268,7 +268,7 @@ contract('DelayedRecoveryModule::executeRecovery', async () => {
         newOwner,
       } = await prepare(accountProvider);
 
-      for (let i = 0; i < recoveryBlockDelay-1; i += 1) {
+      for (let i = 0; i < recoveryBlockDelay - 1; i += 1) {
         // eslint-disable-next-line no-await-in-loop
         await Utils.advanceBlock();
       }

--- a/test/delayed_recovery_module/execute_recovery.js
+++ b/test/delayed_recovery_module/execute_recovery.js
@@ -268,7 +268,7 @@ contract('DelayedRecoveryModule::executeRecovery', async () => {
         newOwner,
       } = await prepare(accountProvider);
 
-      for (let i = 0; i < recoveryBlockDelay; i += 1) {
+      for (let i = 0; i < recoveryBlockDelay-1; i += 1) {
         // eslint-disable-next-line no-await-in-loop
         await Utils.advanceBlock();
       }

--- a/test/pricer_rule/constructor.js
+++ b/test/pricer_rule/constructor.js
@@ -113,12 +113,17 @@ contract('PricerRule::constructor', async () => {
         organization,
       } = await PricerRuleUtils.createOrganization(accountProvider);
 
-      const token = accountProvider.get();
+      const eip20TokenDecimals = 10;
+      const eip20TokenConfig = {
+        symbol: 'OST',
+        name:'Open Simple Token',
+        decimals: eip20TokenDecimals,
+      };
+      const token = await PricerRuleUtils.createEIP20Token(eip20TokenConfig);
       const tokenRules = accountProvider.get();
-
       const pricerRule = await PricerRule.new(
         organization.address,
-        token, // economy token address
+        token.address, // economy token address
         web3.utils.stringToHex('OST'), // base currency code
         10, // conversion rate
         1, // conversion rate decimals
@@ -138,7 +143,7 @@ contract('PricerRule::constructor', async () => {
 
       assert.strictEqual(
         (await pricerRule.eip20Token.call()),
-        token,
+        token.address,
       );
 
       assert.strictEqual(
@@ -156,6 +161,10 @@ contract('PricerRule::constructor', async () => {
 
       assert.isOk(
         (await pricerRule.requiredPriceOracleDecimals.call()).eqn(2),
+      );
+
+      assert.isOk(
+        (await pricerRule.eip20TokenDecimals.call()).eqn(eip20TokenDecimals),
       );
 
       assert.strictEqual(

--- a/test/pricer_rule/constructor.js
+++ b/test/pricer_rule/constructor.js
@@ -116,7 +116,7 @@ contract('PricerRule::constructor', async () => {
       const eip20TokenDecimals = 10;
       const eip20TokenConfig = {
         symbol: 'OST',
-        name:'Open Simple Token',
+        name: 'Open Simple Token',
         decimals: eip20TokenDecimals,
       };
       const token = await PricerRuleUtils.createEIP20Token(eip20TokenConfig);

--- a/test/pricer_rule/pay.js
+++ b/test/pricer_rule/pay.js
@@ -129,7 +129,9 @@ contract('PricerRule::pay', async () => {
         requiredPriceOracleDecimals,
       } = await prepare(accountProvider);
 
-      const acceptanceMargin = (0.002 * (10 ** requiredPriceOracleDecimals)).toString();  // $002 = 2*10^15(in contract)
+      // $0.002 = 0.002*10^18(in contract)
+      const acceptanceMargin = (0.002 * (10 ** requiredPriceOracleDecimals))
+        .toString();
       await pricerRule.setAcceptanceMargin(
         web3.utils.stringToHex(quoteCurrencyCode),
         acceptanceMargin,
@@ -235,8 +237,8 @@ contract('PricerRule::pay', async () => {
 
     it('Checks that TokenRules executeTransfers is called with requiredPriceOracleDecimals = 18.', async () => {
       const config = {
-        requiredPriceOracleDecimals: 18
-      } ;
+        requiredPriceOracleDecimals: 18,
+      };
       const {
         organizationWorker,
         tokenRules,
@@ -249,12 +251,16 @@ contract('PricerRule::pay', async () => {
         fromAddress,
       } = await prepare(accountProvider, config);
 
-      const oraclePrice = (0.02 * (10 ** requiredPriceOracleDecimals)).toString(); // $0.02 = 0.02*10^18(in contract)
+      // $0.02 = 0.02*10^18(in contract)
+      const oraclePrice = (0.02 * (10 ** requiredPriceOracleDecimals))
+        .toString();
       await priceOracle.setPrice(
         oraclePrice,
         (await web3.eth.getBlockNumber()) + 10000,
       );
-      const acceptanceMargin = (1 * (10 ** requiredPriceOracleDecimals)).toString(); // $1 = 1*10^18(in contract)
+      // $1 = 1*10^18(in contract)
+      const acceptanceMargin = (1 * (10 ** requiredPriceOracleDecimals))
+        .toString();
       await pricerRule.setAcceptanceMargin(
         web3.utils.stringToHex(quoteCurrencyCode),
         acceptanceMargin,
@@ -268,7 +274,7 @@ contract('PricerRule::pay', async () => {
       // Amount2 to transfer: $10 = 10*10^18(in contract)
       const amount2BN = (10 * (10 ** requiredPriceOracleDecimals)).toString();
 
-      const intendedPrice = oraclePrice; //intendedPriceBN is Current PriceOracle price
+      const intendedPrice = oraclePrice; // intendedPriceBN is Current PriceOracle price
 
       await pricerRule.pay(
         fromAddress,
@@ -298,10 +304,18 @@ contract('PricerRule::pay', async () => {
       const actualToAddress2 = await tokenRules.recordedTransfersTo.call(1);
       const actualTransfersToLength = await tokenRules.recordedTransfersToLength.call();
 
-      const expectedTransferAmount1 = new BN(1000).mul(tenPowerEighteen); // 1000 BTs = 1000*10^18 BTWei
-      console.log("expectedTransferAmount1:", expectedTransferAmount1.toString(10), "convertedAmount1BN:", convertedAmount1BN.toString(10));
-      const expectedTransferAmount2 = new BN(500).mul(tenPowerEighteen); // 500 BTs = 500*10^18 BTWei
-      console.log("expectedTransferAmount2:", expectedTransferAmount1.toString(10), "convertedAmount2BN:", convertedAmount2BN.toString(10));
+      // 1000 BTs = 1000*10^18 BTWei
+      const expectedTransferAmount1 = new BN(1000).mul(tenPowerEighteen);
+      console.log(
+        'expectedTransferAmount1:', expectedTransferAmount1.toString(10),
+        'convertedAmount1BN:', convertedAmount1BN.toString(10),
+      );
+      // 500 BTs = 500*10^18 BTWei
+      const expectedTransferAmount2 = new BN(500).mul(tenPowerEighteen);
+      console.log(
+        'expectedTransferAmount2:', expectedTransferAmount1.toString(10),
+        'convertedAmount2BN:', convertedAmount2BN.toString(10),
+      );
       const transferredAmount1 = await tokenRules.recordedTransfersAmount.call(0);
       const transferredAmount2 = await tokenRules.recordedTransfersAmount.call(1);
 
@@ -345,13 +359,12 @@ contract('PricerRule::pay', async () => {
       assert.isOk(
         expectedTransferAmount2.eq(convertedAmount2BN),
       );
-
     });
 
     it('Checks that TokenRules executeTransfers is called with requiredPriceOracleDecimals = 5.', async () => {
       const config = {
-        requiredPriceOracleDecimals: 5
-      } ;
+        requiredPriceOracleDecimals: 5,
+      };
       const {
         organizationWorker,
         tokenRules,
@@ -364,12 +377,16 @@ contract('PricerRule::pay', async () => {
         fromAddress,
       } = await prepare(accountProvider, config);
 
-      const oraclePrice = (0.02 * (10 ** requiredPriceOracleDecimals)).toString(); // $0.02 = 0.02*10^5(in contract)
+      // $0.02 = 0.02*10^5(in contract)
+      const oraclePrice = (0.02 * (10 ** requiredPriceOracleDecimals))
+        .toString();
       await priceOracle.setPrice(
         oraclePrice,
         (await web3.eth.getBlockNumber()) + 10000,
       );
-      const acceptanceMargin = (1 * (10 ** requiredPriceOracleDecimals)).toString(); // $1 = 1*10^5(in contract)
+      // $1 = 1*10^5(in contract)
+      const acceptanceMargin = (1 * (10 ** requiredPriceOracleDecimals))
+        .toString();
       await pricerRule.setAcceptanceMargin(
         web3.utils.stringToHex(quoteCurrencyCode),
         acceptanceMargin,
@@ -382,8 +399,8 @@ contract('PricerRule::pay', async () => {
       const amount1BN = (20 * (10 ** requiredPriceOracleDecimals)).toString();
       // Amount2 to transfer: $10 = 10*10^5(in contract)
       const amount2BN = (10 * (10 ** requiredPriceOracleDecimals)).toString();
-
-      const intendedPrice = oraclePrice; //intendedPriceBN is Current PriceOracle price
+      // intendedPriceBN being passed is current PriceOracle price
+      const intendedPrice = oraclePrice;
 
       await pricerRule.pay(
         fromAddress,
@@ -413,12 +430,22 @@ contract('PricerRule::pay', async () => {
       const actualToAddress2 = await tokenRules.recordedTransfersTo.call(1);
       const actualTransfersToLength = await tokenRules.recordedTransfersToLength.call();
 
-      // Number of bt needs to be trasferred for a payment shouldn’t depend on requiredPriceOracleDecimals.
-      // requiredPriceOracleDecimals simply decides minimum value in currency(say USD) that can be transferred.
-      const expectedTransferAmount1 = new BN(1000).mul(tenPowerEighteen); // 1000 BTs = 1000*10^18 BTWei
-      console.log("expectedTransferAmount1:", expectedTransferAmount1.toString(10), "convertedAmount1BN:", convertedAmount1BN.toString(10));
-      const expectedTransferAmount2 = new BN(500).mul(tenPowerEighteen); // 500 BTs = 500*10^18 BTWei
-      console.log("expectedTransferAmount2:", expectedTransferAmount1.toString(10), "convertedAmount2BN:", convertedAmount2BN.toString(10));
+      // Number of bt needs to be trasferred for a payment shouldn’t depend on
+      // requiredPriceOracleDecimals.
+      // requiredPriceOracleDecimals simply decides minimum value in currency(say USD)
+      // that can be transferred.
+      // 1000 BTs = 1000*10^18 BTWei
+      const expectedTransferAmount1 = new BN(1000).mul(tenPowerEighteen);
+      console.log(
+        'expectedTransferAmount1:', expectedTransferAmount1.toString(10),
+        'convertedAmount1BN:', convertedAmount1BN.toString(10),
+      );
+      // 500 BTs = 500*10^18 BTWei
+      const expectedTransferAmount2 = new BN(500).mul(tenPowerEighteen);
+      console.log(
+        'expectedTransferAmount2:', expectedTransferAmount1.toString(10),
+        'convertedAmount2BN:', convertedAmount2BN.toString(10),
+      );
       const transferredAmount1 = await tokenRules.recordedTransfersAmount.call(0);
       const transferredAmount2 = await tokenRules.recordedTransfersAmount.call(1);
 
@@ -462,8 +489,6 @@ contract('PricerRule::pay', async () => {
       assert.isOk(
         transferredAmount2.eq(expectedTransferAmount2),
       );
-
     });
-
   });
 });

--- a/test/pricer_rule/pay.js
+++ b/test/pricer_rule/pay.js
@@ -233,7 +233,7 @@ contract('PricerRule::pay', async () => {
   contract('Positive Paths', async (accounts) => {
     const accountProvider = new AccountProvider(accounts);
 
-    it('Checks that TokenRules executeTransfers is called with requiredPriceOracleDecimals = 18.', async () => {
+    it('Checks that TokenRules executeTransfers is called with requiredPriceOracleDecimals = 18 and eip20TokenDecimals = 18.', async () => {
       const config = {
         requiredPriceOracleDecimals: 18,
       };
@@ -353,7 +353,7 @@ contract('PricerRule::pay', async () => {
       );
     });
 
-    it('Checks that TokenRules executeTransfers is called with requiredPriceOracleDecimals = 5.', async () => {
+    it('Checks that TokenRules executeTransfers is called with requiredPriceOracleDecimals = 5 and eip20TokenDecimals = 18.', async () => {
       const config = {
         requiredPriceOracleDecimals: 5,
       };

--- a/test/pricer_rule/pay.js
+++ b/test/pricer_rule/pay.js
@@ -46,10 +46,11 @@ async function prepare(accountProvider) {
 }
 
 function convertPayCurrencyToToken(
-  amount, price, conversionRate, conversionRateDecimals,
+  requiredPriceOracleDecimals, amount, price, conversionRate, conversionRateDecimals,
 ) {
+  const requiredPriceOracleDecimalsBN = (new BN(10)).pow(requiredPriceOracleDecimals);
   const conversionRateDecimalsBN = (new BN(10)).pow(conversionRateDecimals);
-  return ((amount.mul(conversionRate)).div(price)).div(conversionRateDecimalsBN);
+  return ((requiredPriceOracleDecimalsBN.mul(amount).mul(conversionRate)).div(price)).div(conversionRateDecimalsBN);
 }
 
 contract('PricerRule::pay', async () => {
@@ -269,10 +270,10 @@ contract('PricerRule::pay', async () => {
       );
 
       const convertedAmount1BN = convertPayCurrencyToToken(
-        amount1BN, oraclePriceBN, new BN(conversionRate), new BN(conversionRateDecimals),
+        new BN(requiredPriceOracleDecimals), amount1BN, oraclePriceBN, new BN(conversionRate), new BN(conversionRateDecimals),
       );
       const convertedAmount2BN = convertPayCurrencyToToken(
-        amount2BN, oraclePriceBN, new BN(conversionRate), new BN(conversionRateDecimals),
+        new BN(requiredPriceOracleDecimals), amount2BN, oraclePriceBN, new BN(conversionRate), new BN(conversionRateDecimals),
       );
 
 

--- a/test/pricer_rule/pay.js
+++ b/test/pricer_rule/pay.js
@@ -50,7 +50,11 @@ function convertPayCurrencyToToken(
 ) {
   const requiredPriceOracleDecimalsBN = (new BN(10)).pow(requiredPriceOracleDecimals);
   const conversionRateDecimalsBN = (new BN(10)).pow(conversionRateDecimals);
-  return ((requiredPriceOracleDecimalsBN.mul(amount).mul(conversionRate)).div(price)).div(conversionRateDecimalsBN);
+  return ((requiredPriceOracleDecimalsBN
+    .mul(amount)
+    .mul(conversionRate))
+    .div(price))
+    .div(conversionRateDecimalsBN);
 }
 
 contract('PricerRule::pay', async () => {
@@ -270,10 +274,18 @@ contract('PricerRule::pay', async () => {
       );
 
       const convertedAmount1BN = convertPayCurrencyToToken(
-        new BN(requiredPriceOracleDecimals), amount1BN, oraclePriceBN, new BN(conversionRate), new BN(conversionRateDecimals),
+        new BN(requiredPriceOracleDecimals),
+        amount1BN,
+        oraclePriceBN,
+        new BN(conversionRate),
+        new BN(conversionRateDecimals),
       );
       const convertedAmount2BN = convertPayCurrencyToToken(
-        new BN(requiredPriceOracleDecimals), amount2BN, oraclePriceBN, new BN(conversionRate), new BN(conversionRateDecimals),
+        new BN(requiredPriceOracleDecimals),
+        amount2BN,
+        oraclePriceBN,
+        new BN(conversionRate),
+        new BN(conversionRateDecimals),
       );
 
 

--- a/test/pricer_rule/pay.js
+++ b/test/pricer_rule/pay.js
@@ -601,6 +601,5 @@ contract('PricerRule::pay', async () => {
         expectedTransferAmount2.eq(convertedAmount2BN),
       );
     });
-
   });
 });

--- a/test/pricer_rule/utils.js
+++ b/test/pricer_rule/utils.js
@@ -15,7 +15,6 @@
 'use strict';
 
 const web3 = require('../test_lib/web3.js');
-const BN = require('bn.js');
 
 const EIP20TokenFake = artifacts.require('EIP20TokenFake');
 const TokenRulesSpy = artifacts.require('TokenRulesSpy');
@@ -90,11 +89,10 @@ module.exports.createTokenEconomy = async (accountProvider, config = {}) => {
     tokenRules.address,
   );
 
-  //console.log("pricerRule:", pricerRule.address);
-
   const quoteCurrencyCode = 'USD';
-  const priceOracleInitialPrice = (0.02 * (10 ** requiredPriceOracleDecimals)).toString(); // $0.02 = 2*10^16(in contract)
-  //console.log("priceOracleInitialPrice:", priceOracleInitialPrice);
+  // $0.02 = 0.02*10^18(in contract)
+  const priceOracleInitialPrice = (0.02 * (10 ** requiredPriceOracleDecimals))
+    .toString();
   const initialPriceExpirationHeight = (await web3.eth.getBlockNumber()) + 10000;
 
   const priceOracle = await PriceOracleFake.new(

--- a/test/pricer_rule/utils.js
+++ b/test/pricer_rule/utils.js
@@ -15,6 +15,7 @@
 'use strict';
 
 const web3 = require('../test_lib/web3.js');
+const BN = require('bn.js');
 
 const EIP20TokenFake = artifacts.require('EIP20TokenFake');
 const TokenRulesSpy = artifacts.require('TokenRulesSpy');
@@ -73,11 +74,11 @@ module.exports.createTokenEconomy = async (accountProvider) => {
 
   const baseCurrencyCode = 'OST';
 
-  const conversionRate = 315;
+  // (For 1 OST = 1 BT)
+  const conversionRate = 100000;
+  const conversionRateDecimals = 5;
 
-  const conversionRateDecimals = 2;
-
-  const requiredPriceOracleDecimals = 7;
+  const requiredPriceOracleDecimals = 18;
 
   const pricerRule = await PricerRule.new(
     organization.address,
@@ -89,8 +90,11 @@ module.exports.createTokenEconomy = async (accountProvider) => {
     tokenRules.address,
   );
 
-  const quoteCurrencyCode = 'EUR';
-  const priceOracleInitialPrice = 11;
+  //console.log("pricerRule:", pricerRule.address);
+
+  const quoteCurrencyCode = 'USD';
+  const priceOracleInitialPrice = (0.02 * (10 ** requiredPriceOracleDecimals)).toString(); // $0.02 = 2*10^16(in contract)
+  //console.log("priceOracleInitialPrice:", priceOracleInitialPrice);
   const initialPriceExpirationHeight = (await web3.eth.getBlockNumber()) + 10000;
 
   const priceOracle = await PriceOracleFake.new(

--- a/test/pricer_rule/utils.js
+++ b/test/pricer_rule/utils.js
@@ -29,9 +29,11 @@ const PriceOracleFake = artifacts.require('PriceOracleFake');
  *      - name: 'Open Simple Token'
  *      - decimals: 1
  */
-module.exports.createEIP20Token = async () => {
+module.exports.createEIP20Token = async (config) => {
   const token = await EIP20TokenFake.new(
-    'OST', 'Open Simple Token', 1,
+    config.symbol || 'OST',
+    config.name || 'Open Simple Token',
+    config.decimals || 1,
   );
 
   return token;
@@ -60,14 +62,20 @@ module.exports.createOrganization = async (accountProvider) => {
  * Creates and returns the tuple:
  *      (tokenRules, organizationAddress, token)
  */
-module.exports.createTokenEconomy = async (accountProvider, config = {}) => {
+module.exports.createTokenEconomy = async (accountProvider, config = {}, eip20TokenConfig = {}) => {
   const {
     organization,
     organizationOwner,
     organizationWorker,
   } = await this.createOrganization(accountProvider);
 
-  const token = await this.createEIP20Token();
+  const eip20TokenDecimals = eip20TokenConfig.decimals || 18;
+  const createEIP20TokenConfig = {
+    symbol: eip20TokenConfig.symbol || 'OST',
+    name: eip20TokenConfig.name || 'Open Simple Token',
+    decimals: eip20TokenDecimals,
+  };
+  const token = await this.createEIP20Token(createEIP20TokenConfig);
 
   const tokenRules = await TokenRulesSpy.new();
 
@@ -117,5 +125,6 @@ module.exports.createTokenEconomy = async (accountProvider, config = {}) => {
     quoteCurrencyCode,
     priceOracleInitialPrice,
     priceOracle,
+    eip20TokenDecimals,
   };
 };

--- a/test/pricer_rule/utils.js
+++ b/test/pricer_rule/utils.js
@@ -61,7 +61,7 @@ module.exports.createOrganization = async (accountProvider) => {
  * Creates and returns the tuple:
  *      (tokenRules, organizationAddress, token)
  */
-module.exports.createTokenEconomy = async (accountProvider) => {
+module.exports.createTokenEconomy = async (accountProvider, config = {}) => {
   const {
     organization,
     organizationOwner,
@@ -72,13 +72,13 @@ module.exports.createTokenEconomy = async (accountProvider) => {
 
   const tokenRules = await TokenRulesSpy.new();
 
-  const baseCurrencyCode = 'OST';
+  const baseCurrencyCode = config.baseCurrencyCode || 'OST';
 
   // (For 1 OST = 1 BT)
-  const conversionRate = 100000;
-  const conversionRateDecimals = 5;
+  const conversionRate = config.conversionRate || 100000;
+  const conversionRateDecimals = config.conversionRateDecimals || 5;
 
-  const requiredPriceOracleDecimals = 18;
+  const requiredPriceOracleDecimals = config.requiredPriceOracleDecimals || 18;
 
   const pricerRule = await PricerRule.new(
     organization.address,


### PR DESCRIPTION
The PR adds missing decimals factor in Function `convertPayCurrencyToTokens`.

Added below unit tests:
- requiredPriceOracleDecimals = 18 and eip20TokenDecimals = 18
- requiredPriceOracleDecimals = 5 and eip20TokenDecimals = 18
- requiredPriceOracleDecimals = 18 and eip20TokenDecimals = 5

Theoretically, the Number of BT needs to be transferred for payment shouldn’t depend on requiredPriceOracleDecimals value. If 20 dollar payment needs to be done, it would require 1000 BT for $0.02 per BT value.  Number of BT needs to be transferred shouldn't depend on price oracle decimal. 

requiredPriceOracleDecimals simply decides minimum value in currency(say USD) that can be transferred.

Below two test cases have different price oracle decimals. For test case 1st, requiredPriceOracleDecimals is 18 and the number of BT which will be transferred after the calculation is 1000BT which is expected. 

Total value in USD  = 1000  * 0.02 = **20$**  (where value of each BT is 0.02$)

However for test case two, requiredPriceOracleDecimals is 5 and the number of calculated BT is 10^8 wei BT.  

Total value in USD = (10^8 * 0.02) / (10^18)  = **2*10 ^ (-12) $** 
**Case 1**

_Input_ :

requiredPriceOracleDecimals = 18
payCurrencyAmount = $20 = 20*10^18
baseCurrencyPriceInPayCurrency = $0.02 = 0.02 * 10^18
conversionRateFromBaseCurrencyToToken = 100000 (For 1 OST = 1 BT)
conversionRateDecimalsFromBaseCurrencyToToken = 5
eip20TokenDecimals = 18

_Expected Transferred Amount:_

1000 BT = 1000 * 10^18

_Transferred Amount with Pay method:_

1000 BT = 1000 * 10^18

_Unit Test Status_:

**Pass**

**Case 2**

_Input_ :

requiredPriceOracleDecimals = 5
payCurrencyAmount = $20 = 20*10^5
baseCurrencyPriceInPayCurrency = $0.02 = 0.02 * 10^5
conversionRateFromBaseCurrencyToToken = 100000 (For 1 OST = 1 BT)
conversionRateDecimalsFromBaseCurrencyToToken = 5
eip20TokenDecimals = 18

_Expected Transferred Amount:_

1000 BT = 1000 * 10^18 BTWei

_Transferred Amount with Pay method:_

10^8 BTWei

_Unit Test Status:_

<strike>**Fail**</strike>
Pass

<strike>Travis CI Result:</strike>
<strike>https://travis-ci.org/OpenSTFoundation/openst-contracts/builds/499911526?utm_source=github_status&utm_medium=notification</strike>

Calculation with BT decimal = 20

```
1 OST = 1 BT
BT CR = 10^5
BT CRD = 5
BT Decimal = 20
USD Price Oracle decimal = 18
OST Base Currency decimal = 18

1 OST = 0.02 USD
Transfer 20 USD

Expected Output: 
	1000 BT = 1000*10^18 BTWei

Current PricerRule Implementation Output:

(20*10^18 * 10^5) / (0.02 * 10^18 * 10^5) = 1000 (BT)

Abhay Calculation Output:

(20*10^18 * 10^5) * 10^20 / (0.02 * 10^18 * 10^5) = 1000 * 10^20 BTWei (1000 BT if BT decimal is considered)
As BT Decimal = 10^20, 1000 * 10^20 units = 1000 * 10^20/10^20 = 1000 BT
```

Gist Discussion:
https://gist.github.com/abhayks1/ca49a7db6c0e89ddf4dd9ba568abfac1

cc: @benjaminbollen @pgev @schemar @sarvesh-ost 