### PR TITLE
PricerRule convert payCurrency to Tokens 

### DIFF
--- a/contracts/rules/PricerRule.sol
+++ b/contracts/rules/PricerRule.sol
@@ -398,6 +398,9 @@ contract PricerRule is Organized {
             .mul(
                 conversionRateFromBaseCurrencyToToken
             )
+            .mul(
+                10 ** uint256(requiredPriceOracleDecimals)
+            )
             .div(
                 10 ** conversionRateDecimalsFromBaseCurrencyToToken
             )


### PR DESCRIPTION
Function `convertPayCurrencyToTokens` missed the decimals factor of the Price Oracle;  this change fails one unit test. 

There are also unit tests missing that focus on `convertPayCurrencyToTokens` and please add tests for this.

@abhayks1 can you please review that test and adjust it accordingly. Possibly write more unit tests specifically for this function to confirm this is the appropriate code change.  You can take this commit on your PR (to upstream or my forks branch)