### PR TITLE
Add FirewalledRule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ build/
 .idea/
 .vscode/
 *.iml
+tags
+*.swp
 
 # LaTeX auxiliary files
 *.aux

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ before_install:
   - sudo apt-get install software-properties-common
   - sudo add-apt-repository -y ppa:ethereum/ethereum
 install:
-  - docker pull trailofbits/eth-security-toolbox
   - npm run update
   - export PATH=./node_modules/.bin/:${PATH}
 before_script:

--- a/contracts/rules/FirewalledRule.sol
+++ b/contracts/rules/FirewalledRule.sol
@@ -1,0 +1,105 @@
+pragma solidity ^0.5.0;
+
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import "../organization/OrganizationInterface.sol";
+import "../organization/Organized.sol";
+
+/**
+ * @title Extend this rule in order to restrict relayers of a meta-transaction.
+ *
+ * @notice If you want to restrict the relayers that can relay meta-transactions
+ *         to your rule, you can extend this contract with your rule. Your rule
+ *         has to include the modifier `firewalled` for all functions that
+ *         should be restricted.
+ *         The firewall can be disabled, but not enabled again. When it is
+ *         disabled, the modifier basically does nothing anymore.
+ */
+contract FirewalledRule is Organized {
+
+    /* Events */
+
+    /**
+     * Emitted when the firewall gets disabled.
+     * It is the only event, because a firewall cannot get re-enabled.
+     */
+    event FirewallDisabled();
+
+
+    /* Storage */
+
+    /**
+     * Records whether the firewall is checked in the relevant modifier.
+     * Is set to `false` when the firewall gets disabled.
+     */
+    bool public firewallEnabled;
+
+
+    /* Modifiers */
+
+    /**
+     * Requires that `tx.origin` is an organization worker, if the firewall is
+     * enabled. Once the firewall has been disabled, this modifier will not
+     * enforce any checks anymore.
+     * The modifier checks `tx.origin` and not `msg.sender`, because
+     * `msg.sender` can be another contract. However, what the firewall is
+     * supposed to check is who relayed the meta-transaction. The relayer is
+     * always `tx.origin`.
+     */
+    modifier firewalled() {
+        if (firewallEnabled) {
+            require(
+                // We deliberately chose `tx.origin` and not `msg.sender`.
+                // See modifier documentation for more details.
+                // solium-disable-next-line security/no-tx-origin
+                organization.isWorker(tx.origin),
+                "This method is firewalled. Transaction must originate from an organization worker."
+            );
+        }
+
+        _;
+    }
+
+
+    /* Special Functions */
+
+    /**
+     * @param _organization The address of an organization contract.
+     */
+    constructor(
+        OrganizationInterface _organization
+    )
+        Organized(_organization)
+        public
+    {
+        // The firewall must be enabled by default, as there is no function to
+        // enable a disabled firewall.
+        firewallEnabled = true;
+    }
+
+
+    /* External Functions */
+
+    /**
+     * @notice Disables the firewall so that anyone can use firewalled methods.
+     *         Disabling the firewall cannot be done undone. There is no method
+     *         to enable the firewall again.
+     *         Emits a `FirewallDisabled` event.
+     */
+    function disableFirewall() external onlyOrganization {
+        firewallEnabled = false;
+        emit FirewallDisabled();
+    }
+}

--- a/contracts/test_doubles/unit_tests/firewalled_rule/FirewalledRuleCaller.sol
+++ b/contracts/test_doubles/unit_tests/firewalled_rule/FirewalledRuleCaller.sol
@@ -1,0 +1,47 @@
+pragma solidity ^0.5.0;
+
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import "./FirewalledRuleImplementation.sol";
+
+/**
+ * @title A contract that calls a method that is firewalled.
+ *
+ * @notice The firewalled method explicitly checks for `tx.origin` as opposed to
+ *         `msg.sender`. In order to test the desired behavior, an indirection
+ *         is required. This contract provides exactly that indirection. It
+ *         calls a firewalled method to assert that the firewall works on
+ *         `tx.origin` and not `msg.sender`, as `msg.sender` is this contract.
+ */
+contract FirewalledRuleCaller {
+
+    /* Storage */
+
+    FirewalledRuleImplementation rule;
+
+
+    /* Special Functions */
+
+    constructor(FirewalledRuleImplementation _rule) public {
+        rule = _rule;
+    }
+
+
+    /* External Functions */
+
+    function callFirewalledFn() external view {
+        rule.firewalledFn();
+    }
+}

--- a/contracts/test_doubles/unit_tests/firewalled_rule/FirewalledRuleImplementation.sol
+++ b/contracts/test_doubles/unit_tests/firewalled_rule/FirewalledRuleImplementation.sol
@@ -1,0 +1,44 @@
+pragma solidity ^0.5.0;
+
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import "../../../rules/FirewalledRule.sol";
+
+/**
+ * @title Implementation that actually has a firewalled method.
+ *
+ * @notice As the firewall itself doesn't have any firewalled methods, another
+ *         contract that provides a firewalled method is required in order to
+ *         test the modifier.
+ */
+contract FirewalledRuleImplementation is FirewalledRule {
+
+    /* Special Functions */
+
+    constructor(
+        OrganizationInterface _organization
+    )
+        FirewalledRule(_organization)
+        public
+    // solium-disable-next-line no-empty-blocks
+    {}
+
+
+    /* External Functions */
+
+
+    // solium-disable-next-line no-empty-blocks
+    function firewalledFn() external view firewalled {}
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "test:package": "./npm_package/test/run_npm_package_test.sh",
         "make:package": "node ./npm_package/make_package.js",
         "prepack": "npm-run-all compile:all make:package",
-        "make:all": "npm-run-all lint:sol:solium lint:js lint:sol:slither compile:all test:contracts make:package test:package",
+        "make:all": "npm-run-all lint:sol:solium lint:js compile:all test:contracts make:package test:package",
         "ganache-cli": "./tools/run_ganache_cli.sh"
     },
     "devDependencies": {

--- a/test/firewalled_rule/constructor.js
+++ b/test/firewalled_rule/constructor.js
@@ -1,0 +1,36 @@
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const { AccountProvider } = require('../test_lib/utils');
+const Utils = require('../test_lib/utils.js');
+
+const FirewalledRule = artifacts.require('FirewalledRule');
+
+contract('FirewalledRule::constructor', async () => {
+  contract('Storage', async (accounts) => {
+    const accountProvider = new AccountProvider(accounts);
+
+    it('Checks that the firewall is enabled by default.', async () => {
+      const { organization } = await Utils.createOrganization(accountProvider);
+      const firewalledRule = await FirewalledRule.new(organization.address);
+
+      assert.strictEqual(
+        (await firewalledRule.firewallEnabled.call()),
+        true,
+      );
+    });
+  });
+});

--- a/test/firewalled_rule/disable_firewall.js
+++ b/test/firewalled_rule/disable_firewall.js
@@ -1,0 +1,88 @@
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const { AccountProvider } = require('../test_lib/utils');
+const { Event } = require('../test_lib/event_decoder');
+const Utils = require('../test_lib/utils.js');
+
+const FirewalledRule = artifacts.require('FirewalledRule');
+
+contract('FirewalledRule::disableFirewall', async () => {
+  contract('Negative Tests', async (accounts) => {
+    const accountProvider = new AccountProvider(accounts);
+
+    it('Reverts as non-organization is calling.', async () => {
+      const { organization } = await Utils.createOrganization(accountProvider);
+
+      const firewalledRule = await FirewalledRule.new(organization.address);
+
+      await Utils.expectRevert(
+        firewalledRule.disableFirewall({ from: accountProvider.get() }),
+        'Should revert as a non-organization is calling.',
+        'Only the organization is allowed to call this method.',
+      );
+    });
+  });
+
+  contract('Positive Paths', async (accounts) => {
+    const accountProvider = new AccountProvider(accounts);
+
+    it('Checks that the firewall is disabled after the call.', async () => {
+      const {
+        organization,
+        organizationOwner,
+      } = await Utils.createOrganization(accountProvider);
+
+      const firewalledRule = await FirewalledRule.new(organization.address);
+      await firewalledRule.disableFirewall({ from: organizationOwner });
+
+      assert.strictEqual(
+        (await firewalledRule.firewallEnabled.call()),
+        false,
+      );
+    });
+  });
+
+  contract('Events', async (accounts) => {
+    const accountProvider = new AccountProvider(accounts);
+
+    it('Emits FirewallDisabled.', async () => {
+      const {
+        organization,
+        organizationOwner,
+      } = await Utils.createOrganization(accountProvider);
+
+      const firewalledRule = await FirewalledRule.new(organization.address);
+      const response = await firewalledRule.disableFirewall(
+        { from: organizationOwner },
+      );
+
+      const events = Event.decodeTransactionResponse(
+        response,
+      );
+
+      assert.strictEqual(
+        events.length,
+        1,
+      );
+
+      Event.assertEqual(events[0], {
+        name: 'FirewallDisabled',
+        args: {},
+      });
+    });
+  });
+});

--- a/test/firewalled_rule/firewalled.js
+++ b/test/firewalled_rule/firewalled.js
@@ -1,0 +1,81 @@
+// Copyright 2019 OpenST Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const { AccountProvider } = require('../test_lib/utils');
+const Utils = require('../test_lib/utils.js');
+
+const FirewalledRuleCaller = artifacts.require('FirewalledRuleCaller');
+const FirewalledRuleImplementation = artifacts.require('FirewalledRuleImplementation');
+
+contract('FirewalledRule::firewalled', async () => {
+  contract('Negative Tests', async (accounts) => {
+    const accountProvider = new AccountProvider(accounts);
+
+    it('Reverts as non-organization worker is calling.', async () => {
+      const { organization } = await Utils.createOrganization(accountProvider);
+
+      const firewalledRuleImplementation = await FirewalledRuleImplementation.new(
+        organization.address,
+      );
+      const firewalledRuleCaller = await FirewalledRuleCaller.new(
+        firewalledRuleImplementation.address,
+      );
+
+      await Utils.expectRevert(
+        firewalledRuleCaller.callFirewalledFn({ from: accountProvider.get() }),
+        'Should revert as a non-organization worker is calling.',
+        'This method is firewalled. Transaction must originate from an organization worker.',
+      );
+    });
+  });
+
+  contract('Positive Paths', async (accounts) => {
+    const accountProvider = new AccountProvider(accounts);
+
+    it('Allows a call from a worker.', async () => {
+      const {
+        organization,
+        organizationWorker,
+      } = await Utils.createOrganization(accountProvider);
+
+      const firewalledRuleImplementation = await FirewalledRuleImplementation.new(
+        organization.address,
+      );
+      const firewalledRuleCaller = await FirewalledRuleCaller.new(
+        firewalledRuleImplementation.address,
+      );
+
+      await firewalledRuleCaller.callFirewalledFn({ from: organizationWorker });
+    });
+
+    it('Allows a call from anyone after the firewall is disabled.', async () => {
+      const {
+        organization,
+        organizationOwner,
+      } = await Utils.createOrganization(accountProvider);
+
+      const firewalledRuleImplementation = await FirewalledRuleImplementation.new(
+        organization.address,
+      );
+      await firewalledRuleImplementation.disableFirewall({ from: organizationOwner });
+
+      const firewalledRuleCaller = await FirewalledRuleCaller.new(
+        firewalledRuleImplementation.address,
+      );
+      await firewalledRuleCaller.callFirewalledFn({ from: accountProvider.get() });
+    });
+  });
+});

--- a/test/pricer_rule/constructor.js
+++ b/test/pricer_rule/constructor.js
@@ -28,7 +28,7 @@ contract('PricerRule::constructor', async () => {
     it('Reverts if the token economy address is null.', async () => {
       const {
         organization,
-      } = await PricerRuleUtils.createOrganization(accountProvider);
+      } = await Utils.createOrganization(accountProvider);
 
       await Utils.expectRevert(
         PricerRule.new(
@@ -48,7 +48,7 @@ contract('PricerRule::constructor', async () => {
     it('Reverts if the base currency code is empty.', async () => {
       const {
         organization,
-      } = await PricerRuleUtils.createOrganization(accountProvider);
+      } = await Utils.createOrganization(accountProvider);
 
       await Utils.expectRevert(
         PricerRule.new(
@@ -68,7 +68,7 @@ contract('PricerRule::constructor', async () => {
     it('Reverts if the conversion rate from the base currency to the token is 0.', async () => {
       const {
         organization,
-      } = await PricerRuleUtils.createOrganization(accountProvider);
+      } = await Utils.createOrganization(accountProvider);
 
       await Utils.expectRevert(
         PricerRule.new(
@@ -88,7 +88,7 @@ contract('PricerRule::constructor', async () => {
     it('Reverts if the token rules address is null.', async () => {
       const {
         organization,
-      } = await PricerRuleUtils.createOrganization(accountProvider);
+      } = await Utils.createOrganization(accountProvider);
 
       await Utils.expectRevert(
         PricerRule.new(
@@ -111,7 +111,7 @@ contract('PricerRule::constructor', async () => {
     it('Checks that passed arguments are set correctly.', async () => {
       const {
         organization,
-      } = await PricerRuleUtils.createOrganization(accountProvider);
+      } = await Utils.createOrganization(accountProvider);
 
       const tokenDecimals = 10;
       const eip20TokenConfig = {

--- a/test/pricer_rule/utils.js
+++ b/test/pricer_rule/utils.js
@@ -15,10 +15,10 @@
 'use strict';
 
 const web3 = require('../test_lib/web3.js');
+const Utils = require('../test_lib/utils');
 
 const EIP20TokenFake = artifacts.require('EIP20TokenFake');
 const TokenRulesSpy = artifacts.require('TokenRulesSpy');
-const Organization = artifacts.require('Organization');
 const PricerRule = artifacts.require('PricerRule');
 const PriceOracleFake = artifacts.require('PriceOracleFake');
 
@@ -41,25 +41,6 @@ module.exports.createEIP20Token = async (config) => {
   return token;
 };
 
-module.exports.createOrganization = async (accountProvider) => {
-  const organizationOwner = accountProvider.get();
-  const organizationWorker = accountProvider.get();
-
-  const organization = await Organization.new(
-    organizationOwner,
-    organizationOwner,
-    [organizationWorker],
-    (await web3.eth.getBlockNumber()) + 100000,
-    { from: accountProvider.get() },
-  );
-
-  return {
-    organization,
-    organizationOwner,
-    organizationWorker,
-  };
-};
-
 /**
  * Creates and returns the tuple:
  *      (tokenRules, organizationAddress, token)
@@ -73,7 +54,7 @@ module.exports.createTokenEconomy = async (accountProvider, config = {}, eip20To
     organization,
     organizationOwner,
     organizationWorker,
-  } = await this.createOrganization(accountProvider);
+  } = await Utils.createOrganization(accountProvider);
 
   const tokenDecimals = eip20TokenConfig.decimals;
   const token = await this.createEIP20Token(eip20TokenConfig);

--- a/test/test_lib/utils.js
+++ b/test/test_lib/utils.js
@@ -19,6 +19,8 @@ const assert = require('assert');
 const EthUtils = require('ethereumjs-util');
 const web3 = require('./web3.js');
 
+const Organization = artifacts.require('Organization');
+
 const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 const MAX_UINT256 = new BN(2).pow(new BN(256)).sub(new BN(1));
@@ -200,8 +202,8 @@ module.exports = {
   ) => {
     assert(
       typeof transaction === 'object'
-            && !Array.isArray(transaction)
-            && transaction !== null,
+      && !Array.isArray(transaction)
+      && transaction !== null,
     );
     assert(eventName !== '');
     assert(contractAddress !== '');
@@ -222,5 +224,24 @@ module.exports = {
     assert(typeof param !== 'undefined');
 
     return param;
+  },
+
+  createOrganization: async (accountProvider) => {
+    const organizationOwner = accountProvider.get();
+    const organizationWorker = accountProvider.get();
+
+    const organization = await Organization.new(
+      organizationOwner,
+      organizationOwner,
+      [organizationWorker],
+      (await web3.eth.getBlockNumber()) + 100000,
+      { from: accountProvider.get() },
+    );
+
+    return {
+      organization,
+      organizationOwner,
+      organizationWorker,
+    };
   },
 };

--- a/tools/docker_run_slither.sh
+++ b/tools/docker_run_slither.sh
@@ -9,7 +9,6 @@ container=$(docker run -it -d -v "${root_dir}":/share trailofbits/eth-security-t
 
 docker exec -it "${container}" bash -c \
     "   cd /share \
-     && sudo npm install -g npx \
      && solc-select 0.5.7 \
      && slither . \
         --config-file slither.conf.json \

--- a/tools/docker_run_slither.sh
+++ b/tools/docker_run_slither.sh
@@ -7,10 +7,12 @@ docker pull trailofbits/eth-security-toolbox || exit 1
 
 container=$(docker run -it -d -v "${root_dir}":/share trailofbits/eth-security-toolbox) || exit 1
 
+# Running `slither . --truffle-version truffle` instead of just `slither .` as a workaround.
+# See https://github.com/crytic/eth-security-toolbox/issues/9
 docker exec -it "${container}" bash -c \
     "   cd /share \
      && solc-select 0.5.7 \
-     && slither . \
+     && slither . --truffle-version truffle \
         --config-file slither.conf.json \
     "
 slither_result=$?

--- a/tools/docker_run_slither.sh
+++ b/tools/docker_run_slither.sh
@@ -9,6 +9,7 @@ container=$(docker run -it -d -v "${root_dir}":/share trailofbits/eth-security-t
 
 docker exec -it "${container}" bash -c \
     "   cd /share \
+     && sudo npm install -g npx \
      && solc-select 0.5.7 \
      && slither . \
         --config-file slither.conf.json \


### PR DESCRIPTION
I added a FirewalledRule which can be extended in order to restrict
relaying of meta-transactions to organization workers.
The rule that is to be restricted must extend the FirewalledRule and add
the modifier `firewalled` to all relevant functions.

For testing I created two test contract files. One that uses the
modifier, and one that calls the one that uses the modifier. Required in
order to simulate rules calling on each other and checking for the
relayer.

Added a step to manually install npx inside docker until the docker
image is fixed. The problem is reported and confirmed at
https://github.com/crytic/eth-security-toolbox/issues/8

Fixes #199